### PR TITLE
Feature/user registration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,7 @@
 /.bundle
 
 # Ignore all environment files.
-/.env*
+# /.env*
 
 # Ignore all default key files.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "thruster", require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
+gem "devise"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "thruster", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 gem "devise"
 gem "devise-jwt"
 

--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,6 @@ group :development, :test do
 
   gem "pry-rails"
   gem "dotenv-rails"
-end
-
-group :development, :test do
   gem "rspec-rails"
   gem "factory_bot_rails"
   gem "faker"

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem "rubocop-rails-omakase", require: false
 
   gem "pry-rails"
+  gem "dotenv-rails"
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "thruster", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 gem "devise"
+gem "devise-jwt"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
       warden-jwt_auth (~> 0.10)
     diff-lcs (1.6.2)
     dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.3)
     dry-auto_inject (1.1.0)
       dry-core (~> 1.1)
@@ -381,6 +384,7 @@ DEPENDENCIES
   debug
   devise
   devise-jwt
+  dotenv-rails
   factory_bot_rails
   faker
   kamal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,9 +97,22 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-jwt (0.12.1)
+      devise (~> 4.0)
+      warden-jwt_auth (~> 0.10)
     diff-lcs (1.6.2)
     dotenv (3.1.8)
     drb (2.2.3)
+    dry-auto_inject (1.1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-configurable (1.3.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
     ed25519 (1.4.0)
     erb (5.0.1)
     erubi (1.13.1)
@@ -125,6 +138,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.12.2)
+    jwt (2.10.2)
+      base64
     kamal (2.7.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -337,6 +352,11 @@ GEM
     useragent (0.16.11)
     warden (1.2.9)
       rack (>= 2.0.9)
+    warden-jwt_auth (0.11.0)
+      dry-auto_inject (>= 0.8, < 2)
+      dry-configurable (>= 0.13, < 2)
+      jwt (~> 2.1)
+      warden (~> 1.2)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -357,6 +377,7 @@ DEPENDENCIES
   brakeman
   debug
   devise
+  devise-jwt
   factory_bot_rails
   faker
   kamal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,9 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.16)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -384,6 +387,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-rails
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.0.2)
   rspec-rails
   rubocop-rails-omakase

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
@@ -90,6 +91,12 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    devise (4.9.4)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
     diff-lcs (1.6.2)
     dotenv (3.1.8)
     drb (2.2.3)
@@ -172,6 +179,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-musl)
       racc (~> 1.4)
+    orm_adapter (0.5.0)
     ostruct (0.6.2)
     parallel (1.27.0)
     parser (3.3.8.0)
@@ -239,6 +247,9 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    responders (3.1.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -324,6 +335,8 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -343,6 +356,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  devise
   factory_bot_rails
   faker
   kamal

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::API
+  include ActionController::MimeResponds
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  respond_to :json
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :email, :password, :password_confirmation ])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [ :email, :password ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :password, :password_confirmation ])
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,15 @@ class ApplicationController < ActionController::API
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :email, :password, :password_confirmation ])
+    added_keys = [
+      :email, :password, :password_confirmation,
+      :first_name, :last_name,
+      :first_name_kana, :last_name_kana,
+      :birth_date, :phone_number,
+      :gender, :prefecture
+    ]
+    devise_parameter_sanitizer.permit(:sign_up, keys: added_keys)
     devise_parameter_sanitizer.permit(:sign_in, keys: [ :email, :password ])
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :password, :password_confirmation ])
+    devise_parameter_sanitizer.permit(:account_update, keys: added_keys)
   end
 end

--- a/app/controllers/concerns/rack_session_fix.rb
+++ b/app/controllers/concerns/rack_session_fix.rb
@@ -1,0 +1,15 @@
+module RackSessionFix
+  extend ActiveSupport::Concern
+  class FakeRackSession < Hash
+    def enabled?
+      false
+    end
+  end
+  included do
+    before_action :set_fake_rack_session_for_devise
+    private
+    def set_fake_rack_session_for_devise
+      request.env["rack.session"] ||= FakeRackSession.new
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  include RackSessionFix
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+  private
+
+  def respond_with(resource, _opts = {})
+    register_success && return if resource.persisted?
+
+    register_failed
+  end
+
+  def register_success
+    render json: { message: "Signed up successfully.", user: resource }, status: :ok
+  end
+
+  def register_failed
+    render json: {
+      message: "Signed up failure.",
+      errors: resource.errors.full_messages
+    }, status: :unprocessable_entity
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -63,12 +63,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   private
 
   def respond_with(resource, _opts = {})
-    register_success && return if resource.persisted?
+    register_success(resource) && return if resource.persisted?
 
     register_failed
   end
 
-  def register_success
+  def register_success(resource)
+    sign_in(resource)
     render json: { message: "Signed up successfully.", user: resource }, status: :ok
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  include RackSessionFix
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+  private
+
+  def respond_with(resource, _opts = {})
+    render json: { message: "Logged in successfully.", user: resource }, status: :ok
+  end
+
+  def respond_to_on_destroy
+    current_user ? log_out_success : log_out_failure
+  end
+
+  def log_out_success
+    render json: { message: "Logged out successfully." }, status: :ok
+  end
+
+  def log_out_failure
+    render json: { message: "Logged out failure." }, status: :unauthorized
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+class UsersController < ApplicationController
+  include RackSessionFix
+  before_action :authenticate_user!
+  def me
+    render json: current_user, status: :ok
+  end
+end

--- a/app/models/jwt_denylist.rb
+++ b/app/models/jwt_denylist.rb
@@ -1,0 +1,2 @@
+class JwtDenylist < ApplicationRecord
+end

--- a/app/models/jwt_denylist.rb
+++ b/app/models/jwt_denylist.rb
@@ -1,2 +1,5 @@
 class JwtDenylist < ApplicationRecord
+  include Devise::JWT::RevocationStrategies::Denylist
+
+  self.table_name = "jwt_denylists"
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,16 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :validatable,
+         :jwt_authenticatable, jwt_revocation_strategy: self
+
+  # トークン無効化の判定（今回は常に false = 無効化しない）
+  def self.jwt_revoked?(_payload, _user)
+    false
+  end
+
+  # トークンが使われたときの記録処理（今回は何もしない）
+  def self.revoke_jwt(_payload, _user)
+    # no-op
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,15 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :validatable,
-         :jwt_authenticatable, jwt_revocation_strategy: self
-
-  # トークン無効化の判定（今回は常に false = 無効化しない）
-  def self.jwt_revoked?(_payload, _user)
-    false
-  end
-
-  # トークンが使われたときの記録処理（今回は何もしない）
-  def self.revoke_jwt(_payload, _user)
-    # no-op
-  end
+         :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :validatable,
          :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
+
+  enum gender: { male: 1, female: 2, other: 3 }, _prefix: true
+
+  validates :first_name, :last_name, :birth_date, :first_name_kana, :last_name_kana, :phone_number, :gender, :prefecture, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
          :recoverable, :validatable,
          :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
 
-  enum gender: { male: 1, female: 2, other: 3 }, _prefix: true
+  # enum gender: { male: 1, female: 2, other: 3 }, _prefix: true
+  enum :gender, male: 1, female: 2, other: 3
 
   validates :first_name, :last_name, :birth_date, :first_name_kana, :last_name_kana, :phone_number, :gender, :prefecture, presence: true
 end

--- a/compose.yml
+++ b/compose.yml
@@ -33,6 +33,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    env_file:
+      - .env
 volumes:
   bundle_data:
   postgresql_data:

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,7 @@ require "rails/all"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+Dotenv::Rails.load if defined?(Dotenv)
 
 module Myapp
   class Application < Rails::Application

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,13 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV.fetch("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
+
+    resource "*",
+      headers: :any,
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ],
+      expose: %w[Authorization]
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,7 +263,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+  config.navigational_formats = []
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,4 +310,14 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+  config.jwt do |jwt|
+    jwt.secret = Rails.application.credentials.dig(:devise, :jwt_secret_key) || ENV["DEVISE_JWT_SECRET_KEY"]
+    jwt.dispatch_requests = [
+      [ "POST", %r{^/api/v1/users/sign_in$} ]
+    ]
+    jwt.revocation_requests = [
+      [ "DELETE", %r{^/api/v1/users/sign_out$} ]
+    ]
+    jwt.expiration_time = 1.day.to_i
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '0ca00d43074ce4c10d9b260b8e9a968321f9d16c4074ee0d05aa1405c30f3241131699184f6e5e3f61b1e8c148214024a91d160c001c87684162916442c30f35'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require "devise/orm/active_record"
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [ :email ]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [ :email ]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [ :http_auth ]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'eda8d18c55b03997595da5e5ea5c6fbf3cd3a1cfae465cf53f24c0f3a8e70ac8984983800b15883bac3b193ffcc5cf7c0186b38557559b309564bdae6029ec55'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -28,7 +28,7 @@ threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+port ENV.fetch("PORT", 3000), "0.0.0.0"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,17 @@
 Rails.application.routes.draw do
-  namespace :api do
-    namespace :v1 do
-      devise_for :users,
-           controllers: {
-             registrations: "api/v1/users/registrations",
-             sessions: "api/v1/users/sessions"
-           },
-           path: "",
-           path_names: {
-             sign_in: "login",
-             sign_out: "logout",
-             registration: "signup"
-           },
-           defaults: { format: :json },
-           skip: [ :passwords, :confirmations, :unlocks ]
-    end
-  end
+  devise_for :users,
+        controllers: {
+          registrations: "users/registrations",
+          sessions: "users/sessions"
+        },
+        path: "",
+        path_names: {
+          sign_in: "login",
+          sign_out: "logout",
+          registration: "signup"
+        },
+        defaults: { format: :json },
+        skip: [ :passwords, :confirmations, :unlocks ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
+  get "/me", to: "users#me"
 
   # Defines the root path route ("/")
   # root "posts#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,21 @@
 Rails.application.routes.draw do
-  devise_for :users
+  namespace :api do
+    namespace :v1 do
+      devise_for :users,
+           controllers: {
+             registrations: "api/v1/users/registrations",
+             sessions: "api/v1/users/sessions"
+           },
+           path: "",
+           path_names: {
+             sign_in: "login",
+             sign_out: "logout",
+             registration: "signup"
+           },
+           defaults: { format: :json },
+           skip: [ :passwords, :confirmations, :unlocks ]
+    end
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250711053902_devise_create_users.rb
+++ b/db/migrate/20250711053902_devise_create_users.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20250712124409_create_jwt_denylists.rb
+++ b/db/migrate/20250712124409_create_jwt_denylists.rb
@@ -1,0 +1,10 @@
+class CreateJwtDenylists < ActiveRecord::Migration[8.0]
+  def change
+    create_table :jwt_denylists do |t|
+      t.string :jti, null: false
+      t.datetime :exp, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250712124917_add_index_to_jwt_denylist.rb
+++ b/db/migrate/20250712124917_add_index_to_jwt_denylist.rb
@@ -1,0 +1,5 @@
+class AddIndexToJwtDenylist < ActiveRecord::Migration[8.0]
+  def change
+    add_index :jwt_denylists, :jti, unique: true
+  end
+end

--- a/db/migrate/20250715054650_add_user_details_to_users.rb
+++ b/db/migrate/20250715054650_add_user_details_to_users.rb
@@ -1,0 +1,12 @@
+class AddUserDetailsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :last_name, :string, null: false
+    add_column :users, :first_name, :string, null: false
+    add_column :users, :last_name_kana, :string, null: false
+    add_column :users, :first_name_kana, :string, null: false
+    add_column :users, :phone_number, :string, null: false
+    add_column :users, :birth_date, :date, null: false
+    add_column :users, :gender, :integer, null: false
+    add_column :users, :prefecture, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_11_053902) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_12_124409) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "jwt_denylists", force: :cascade do |t|
+    t.string "jti", null: false
+    t.datetime "exp", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_12_124917) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_15_054650) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -30,6 +30,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_12_124917) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "last_name", null: false
+    t.string "first_name", null: false
+    t.string "last_name_kana", null: false
+    t.string "first_name_kana", null: false
+    t.string "phone_number", null: false
+    t.date "birth_date", null: false
+    t.integer "gender", null: false
+    t.string "prefecture", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,28 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_07_11_053902) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_12_124409) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_12_124917) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_12_124409) do
     t.datetime "exp", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["jti"], name: "index_jwt_denylists_on_jti", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/jwt_denylists.rb
+++ b/spec/factories/jwt_denylists.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :jwt_denylist do
+    jti { "MyString" }
+    exp { "2025-07-12 21:44:09" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :user do
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,16 @@
 FactoryBot.define do
   factory :user do
+    first_name { "太郎" }
+    last_name  { "山田" }
+    first_name_kana { "たろう" }
+    last_name_kana  { "やまだ" }
+    birth_date { Date.new(2000, 1, 1) }
+    phone_number { "09012345678" }
+    gender { :male }
+    prefecture { "東京都" }
+
+    email { Faker::Internet.email }
+    password { "password123" }
+    password_confirmation { "password123" }
   end
 end

--- a/spec/models/jwt_denylist_spec.rb
+++ b/spec/models/jwt_denylist_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe JwtDenylist, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーション" do
+    subject { build(:user) }
+
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:first_name_kana) }
+    it { is_expected.to validate_presence_of(:last_name_kana) }
+    it { is_expected.to validate_presence_of(:birth_date) }
+    it { is_expected.to validate_presence_of(:phone_number) }
+    it { is_expected.to validate_presence_of(:gender) }
+    it { is_expected.to validate_presence_of(:prefecture) }
+
+    it { is_expected.to define_enum_for(:gender).with_values(male: 1, female: 2, other: 3) }
+  end
 end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe "User Registration API", type: :request do
+  let(:valid_params) do
+    {
+      user: {
+        email: "test@example.com",
+        password: "password123",
+        password_confirmation: "password123",
+        first_name: "太郎",
+        last_name: "山田",
+        first_name_kana: "たろう",
+        last_name_kana: "やまだ",
+        birth_date: "2000-01-01",
+        phone_number: "09012345678",
+        gender: "male",
+        prefecture: "東京都"
+      }
+    }
+  end
+
+  let(:invalid_params) do
+    {
+      user: {
+        email: "",
+        password: "short",
+        password_confirmation: "mismatch"
+      }
+    }
+  end
+
+  describe "POST /signup" do
+    it "creates a new user with valid params" do
+      post "/signup", params: valid_params
+
+      expect(response).to have_http_status(:created).or have_http_status(:ok)
+      expect(JSON.parse(response.body)["user"]["email"]).to eq("test@example.com")
+      expect(response.headers["Authorization"]).to be_present
+    end
+
+    it "returns errors with invalid params" do
+      post "/signup", params: invalid_params
+
+      expect(response).to have_http_status(:unprocessable_entity).or have_http_status(:bad_request)
+      expect(JSON.parse(response.body)).to have_key("errors").or have_key("message")
+    end
+
+    it "returns an error when email is already taken" do
+      # 先にユーザーを作成しておく
+      post "/signup", params: valid_params
+      expect(response).to have_http_status(:created).or have_http_status(:ok)
+
+      # 同じemailで再登録を試みる
+      post "/signup", params: valid_params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json["message"]).to eq("Signed up failure.")
+      expect(json["errors"]).to include("Email has already been taken")
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "User Login API", type: :request do
+  let!(:user) { create(:user, email: "login@example.com", password: "password123", password_confirmation: "password123") }
+
+  let(:valid_params) do
+    {
+      user: {
+        email: "login@example.com",
+        password: "password123"
+      }
+    }
+  end
+
+  let(:invalid_params) do
+    {
+      user: {
+        email: "login@example.com",
+        password: "wrongpassword"
+      }
+    }
+  end
+
+  describe "POST /login" do
+    it "logs in the user with valid credentials" do
+      post "/login", params: valid_params
+
+      expect(response).to have_http_status(:ok).or have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json["message"]).to eq("Logged in successfully.")
+      expect(response.headers["Authorization"]).to be_present
+    end
+
+    it "fails to log in with invalid credentials" do
+      post "/login", params: invalid_params
+
+      expect(response).to have_http_status(:unauthorized).or have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to eq("Invalid Email or password.")
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -39,4 +39,25 @@ RSpec.describe "User Login API", type: :request do
       expect(json["error"]).to eq("Invalid Email or password.")
     end
   end
+
+  describe "DELETE /logout" do
+    it "logs out the user with valid JWT token" do
+      # 1. ログインしてJWTトークンを取得
+      post "/login", params: valid_params
+      token = response.headers["Authorization"]
+
+      # 2. トークン付きでログアウトを実行
+      delete "/logout", headers: { "Authorization" => token }
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["message"]).to eq("Logged out successfully.")
+    end
+
+    it "returns unauthorized when JWT token is missing" do
+      delete "/logout"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,10 +1,36 @@
 require 'rails_helper'
 
-RSpec.describe "Users", type: :request do
-  describe "GET /me" do
-    it "returns http success" do
-      get "/users/me"
-      expect(response).to have_http_status(:success)
-    end
+RSpec.describe "GET /me", type: :request do
+  let!(:user) do
+    create(:user, email: "me@example.com", password: "password123", password_confirmation: "password123")
+  end
+
+  let(:login_params) do
+    {
+      user: {
+        email: "me@example.com",
+        password: "password123"
+      }
+    }
+  end
+
+  it "returns current user info when authorized" do
+    # 1. ログインしてJWTを取得
+    post "/login", params: login_params
+    token = response.headers["Authorization"]
+
+    # 2. JWT付きで /me を叩く
+    get "/me", headers: { "Authorization" => token }
+
+    expect(response).to have_http_status(:ok)
+    json = JSON.parse(response.body)
+    expect(json["email"]).to eq("me@example.com")
+    expect(json["first_name"]).to eq(user.first_name)
+    expect(json["last_name"]).to eq(user.last_name)
+  end
+
+  it "returns unauthorized without JWT" do
+    get "/me"
+    expect(response).to have_http_status(:unauthorized)
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  describe "GET /me" do
+    it "returns http success" do
+      get "/users/me"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
ユーザー登録機能（/signup）をJWTベースで実装し、関連するログイン・ログアウト・現在のユーザー取得（/me）までのAPIフローを構築しました。また、各機能に対してRSpecによるリクエストテストも追加しました。

## 主な変更点
- Userモデルに会員登録フォームに必要な属性を追加
  - first_name, last_name, first_name_kana, last_name_kana, birth_date, phone_number, gender(enum), prefecture
- Devise + devise-jwt によるJWT認証の導入
- ユーザー登録API `/signup` の実装
  - 登録時にJWTを発行し、Authorizationヘッダーに含めて返却
- ログインAPI `/login` の実装
- ログアウトAPI `/logout` の実装（JWTトークンの失効処理）
- ログインユーザー取得API `/me` の実装
- 各APIに対するRSpecリクエストテストの作成
  - ユーザー登録・ログイン・ログアウト・現在のユーザー取得
  - エラーパターン（バリデーションエラーやトークン未付与など）もカバー

## 補足
- `enum gender` の記法は Rails 8 に合わせて `enum :gender, male: 1, female: 2, other: 3` を使用しています
- 登録成功時に `sign_in` を呼び出してJWTを即時発行しています
- Authorizationヘッダーがない場合の挙動（401）もテストで確認済みです