### PR TITLE
JWTをHttpOnly Cookieに保存する認証方式の導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,10 +18,4 @@ class ApplicationController < ActionController::API
     devise_parameter_sanitizer.permit(:sign_in, keys: [ :email, :password ])
     devise_parameter_sanitizer.permit(:account_update, keys: added_keys)
   end
-
-  def set_jwt_from_cookie
-    if cookies.signed[:jwt]
-      request.headers["Authorization"] = "Bearer #{cookies.signed[:jwt]}"
-    end
-  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -70,6 +70,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def register_success(resource)
     sign_in(resource)
+
+    token = Warden::JWTAuth::UserEncoder.new.call(resource, :user, nil).first
+      cookies.signed[:jwt] = {
+        value: token,
+        httponly: true,
+        secure: Rails.env.production?,
+        same_site: :lax
+      }
     render json: { message: "Signed up successfully.", user: resource }, status: :ok
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "warden/jwt_auth"
+
 class Users::SessionsController < Devise::SessionsController
   include RackSessionFix
   # before_action :configure_sign_in_params, only: [:create]
@@ -16,7 +18,6 @@ class Users::SessionsController < Devise::SessionsController
     if self.resource
       sign_in(resource_name, resource)
 
-      p "User signed in: #{resource.email}"
       token = Warden::JWTAuth::UserEncoder.new.call(resource, :user, nil).first
       cookies.signed[:jwt] = {
         value: token,
@@ -32,9 +33,10 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    cookies.delete(:jwt, secure: Rails.env.production?, same_site: :lax)
+    super
+  end
 
   # protected
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,15 @@
 class UsersController < ApplicationController
   include RackSessionFix
+  before_action :set_jwt_from_cookie, only: [ :me ]
   before_action :authenticate_user!
   def me
     render json: current_user, status: :ok
+  end
+
+  private
+  def set_jwt_from_cookie
+    if cookies.signed[:jwt]
+      request.headers["Authorization"] = "Bearer #{cookies.signed[:jwt]}"
+    end
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -313,10 +313,10 @@ Devise.setup do |config|
   config.jwt do |jwt|
     jwt.secret = Rails.application.credentials.dig(:devise, :jwt_secret_key) || ENV["DEVISE_JWT_SECRET_KEY"]
     jwt.dispatch_requests = [
-      [ "POST", %r{^/api/v1/users/sign_in$} ]
+      [ "POST", %r{^/login$} ]
     ]
     jwt.revocation_requests = [
-      [ "DELETE", %r{^/api/v1/users/sign_out$} ]
+      [ "DELETE", %r{^/logout$} ]
     ]
     jwt.expiration_time = 1.day.to_i
   end


### PR DESCRIPTION
## 概要

ログイン時にJWTをHttpOnly Cookieとして保存し、以降のリクエストではAuthorizationヘッダーではなくCookie経由で認証できるように対応しました。

## 変更点

- Devise JWT により発行されたトークンを、ログイン時に Cookie に保存するようセッションコントローラを拡張
- Cookie に保存されたJWTを読み取り、Authorizationヘッダーに変換する `JwtCookieAuth` concern を追加
- `ActionController::Cookies` を `ApplicationController` に追加し、`cookies` メソッドを利用可能に

## 備考

- フロントエンドでは fetch 時に `credentials: "include"` が必要です
- CORS 対応については別途確認が必要です（`config/initializers/cors.rb` の修正）