### PR TITLE
fix: set_jwt_cookieをヘルパーに変更

### DIFF
--- a/app/controllers/concerns/jwt_cookie_helper.rb
+++ b/app/controllers/concerns/jwt_cookie_helper.rb
@@ -1,0 +1,21 @@
+module JwtCookieHelper
+  def set_jwt_cookie(resource)
+    token = Warden::JWTAuth::UserEncoder.new.call(resource, :user, nil).first
+
+    same_site =
+      if Rails.env.production?
+        allowed_origins = ENV.fetch("CORS_ALLOWED_ORIGINS", "").split(",")
+        origin = request.headers["Origin"]
+        allowed_origins.include?(origin) ? :none : :lax
+      else
+        :lax
+      end
+
+    cookies.signed[:jwt] = {
+      value: token,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: same_site
+    }
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,6 +2,7 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   include RackSessionFix
+  include JwtCookieHelper
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
@@ -70,14 +71,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def register_success(resource)
     sign_in(resource)
-
-    token = Warden::JWTAuth::UserEncoder.new.call(resource, :user, nil).first
-      cookies.signed[:jwt] = {
-        value: token,
-        httponly: true,
-        secure: Rails.env.production?,
-        same_site: :lax
-      }
+    set_jwt_cookie(resource)
     render json: { message: "Signed up successfully.", user: resource }, status: :ok
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,6 +4,7 @@ require "warden/jwt_auth"
 
 class Users::SessionsController < Devise::SessionsController
   include RackSessionFix
+  include JwtCookieHelper
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -17,15 +18,7 @@ class Users::SessionsController < Devise::SessionsController
 
     if self.resource
       sign_in(resource_name, resource)
-
-      token = Warden::JWTAuth::UserEncoder.new.call(resource, :user, nil).first
-      cookies.signed[:jwt] = {
-        value: token,
-        httponly: true,
-        secure: Rails.env.production?,
-        same_site: :lax
-      }
-
+      set_jwt_cookie(resource)
       render json: { message: "ログインに成功しました", user: resource }, status: :ok
     else
       render json: { message: "ログインに失敗しました", errors: [ "メールアドレスまたはパスワードが正しくありません" ] }, status: :unauthorized


### PR DESCRIPTION
## 概要

`registrations_controller.rb` と `sessions_controller.rb` に重複していた JWT Cookie の設定処理を共通メソッド `set_jwt_cookie` に抽出しました。  
セキュリティの観点から、`Origin` ヘッダーと `CORS_ALLOWED_ORIGINS` を比較して `same_site` を動的に切り替えるロジックも統一しました。

## 変更内容

- `set_jwt_cookie(resource)` メソッドを `JwtCookieHelper` モジュールとして追加
- `registrations_controller.rb` と `sessions_controller.rb` で共通メソッドを使用
- 重複コードの削除