### PR TITLE
fix: ログアウト時に必ずdelete_jwt_cookieを使うように変更

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,10 +26,9 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   # DELETE /resource/sign_out
-  def destroy
-    delete_jwt_cookie
-    super
-  end
+  # def destroy
+  #   super
+  # end
 
   # protected
 
@@ -44,14 +43,7 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def respond_to_on_destroy
-    current_user ? log_out_success : log_out_failure
-  end
-
-  def log_out_success
+    delete_jwt_cookie
     render json: { message: "Logged out successfully." }, status: :ok
-  end
-
-  def log_out_failure
-    render json: { message: "Logged out failure." }, status: :unauthorized
   end
 end


### PR DESCRIPTION
## 概要

ログアウト処理 `/logout` において、既に無効化されたJWTで再度アクセスされた場合にも `401 Unauthorized` を返さず、
安定して `200 OK` を返すように変更しました。

## 背景

JWTがすでに `JwtDenylist` に登録済みの場合、Deviseは `current_user` を `nil` と判定し `401` を返す挙動になります。
しかし、ユーザー体験やAPI設計としては「ログアウト済みである」ことを正常完了と扱うほうが自然なケースが多いため、
`respond_to_on_destroy` をシンプルに書き換えて対応しました。

## 変更内容

- `respond_to_on_destroy` メソッドを上書きし、常に `200 OK` を返すように変更
- Cookie削除処理 `delete_jwt_cookie` はそのまま実行
